### PR TITLE
Use Scale-independent pixels

### DIFF
--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="activity_margin">8dp</dimen>
-    <dimen name="item_height">48dp</dimen>
-    <dimen name="item_icon_padding">8dp</dimen>
-    <dimen name="item_margin_vertical">4dp</dimen>
-    <dimen name="empty_list_padding">16dp</dimen>
+    <dimen name="activity_margin">8sp</dimen>
+    <dimen name="item_height">48sp</dimen>
+    <dimen name="item_icon_padding">8sp</dimen>
+    <dimen name="item_margin_vertical">4sp</dimen>
+    <dimen name="empty_list_padding">16sp</dimen>
 </resources>


### PR DESCRIPTION
Fixes issues with non-default font sizes.

See https://developer.android.com/guide/topics/resources/more-resources#Dimension