### PR TITLE
Fix NPE in PreferredAppsAdapter

### DIFF
--- a/app/src/main/java/de/ub0r/android/choosebrowser/PreferredAppsAdapter.java
+++ b/app/src/main/java/de/ub0r/android/choosebrowser/PreferredAppsAdapter.java
@@ -97,6 +97,7 @@ public class PreferredAppsAdapter extends RecyclerView.Adapter<PreferredAppsAdap
         mStore = store;
         mItems = new ArrayList<>();
         final ArrayList<String> keys = new ArrayList<>(mStore.list());
+        while (keys.remove(null));
         Collections.sort(keys);
         for (final String key : keys) {
             mItems.add(new ContentHolder(key, mStore.get(key)));


### PR DESCRIPTION
Crashed when selecting "Preferred apps".

Fixes #14

Error was:
```
04-10 14:56:55.231 20176 20176 E AndroidRuntime: Caused by: java.lang.NullPointerException: rhs == null
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at java.lang.String.compareTo(Native Method)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at java.lang.String.compareTo(String.java:125)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at java.util.ComparableTimSort.countRunAndMakeAscending(ComparableTimSort.java:320)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at java.util.ComparableTimSort.sort(ComparableTimSort.java:202)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at java.util.Arrays.sort(Arrays.java:1305)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at java.util.Arrays.sort(Arrays.java:1488)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at java.util.ArrayList.sort(ArrayList.java:1470)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at java.util.Collections.sort(Collections.java:206)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at java.util.Collections.sort(Collections.java:159)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at de.ub0r.android.choosebrowser.PreferredAppsAdapter.<init>(PreferredAppsAdapter.java:100)
04-10 14:56:55.231 20176 20176 E AndroidRuntime: 	at de.ub0r.android.choosebrowser.PreferredAppsActivity.onCreate(PreferredAppsActivity.java:27)
```